### PR TITLE
Console: require ncurses as a curses implementation

### DIFF
--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -53,8 +53,15 @@ if(MSVC)
 else()
     # lots of warnings
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic)
-    
+
     #additional libraries
+    # Use CURSES_NEED_NCURSES to enable termcap compatibility API in ncurses
+    # (needed for tgoto() from <term.h>). Some Linux distributions don't provide
+    # it by default as part of -lcurses / -lncurses:
+    #    https://bugs.gentoo.org/836155
+    #    https://gitlab.kitware.com/cmake/cmake/-/issues/23236
+    # The alternative would be to detect the need for a termcap library.
+    set(CURSES_NEED_NCURSES TRUE)
     find_package(Curses REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CURSES_LIBRARY})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${CURSES_LIBRARIES})
 endif()


### PR DESCRIPTION
multitextor uses termcap <term.h> (or terminfo) APIs like tgoto().
Some distributions provide it as part of -lcurses (like Fedore and
Ubuntu). But some don't (like Gentoo: https://bugs.gentoo.org/836155).

Cmake also does not enable it by default:
    https://gitlab.kitware.com/cmake/cmake/-/issues/23236

As a result on Gentoo multitextor build fails as:

    [ 60%] Linking CXX executable ../../_build/bin/multitextor
    ld: ../Console/libConsoleLib.a(ScreenTTY.cpp.o): undefined reference to symbol 'tgoto'
    ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status

The change enables CURSES_NEED_NCURSES flag to pull in -ltinfo.